### PR TITLE
Update Racket from 6.1 to 6.4, http to https

### DIFF
--- a/racket/tools/chocolateyInstall.ps1
+++ b/racket/tools/chocolateyInstall.ps1
@@ -1,7 +1,7 @@
 ﻿$packageName = 'racket'
 $installerType = 'EXE'
-$url = 'http://mirror.racket-lang.org/installers/6.1/racket-6.1-i386-win32.exe'
-$url64 = 'http://mirror.racket-lang.org/installers/6.1/racket-6.1-x86_64-win32.exe'
+$url = 'https://mirror.racket-lang.org/installers/6.4/racket-6.4-i386-win32.exe'
+$url64 = 'https://mirror.racket-lang.org/installers/6.4/racket-6.4-x86_64-win32.exe'
 $silentArgs = '/S'
 $validExitCodes = @(0) #please insert other valid exit codes here, exit codes for ms http://msdn.microsoft.com/en-us/library/aa368542(VS.85).aspx
 


### PR DESCRIPTION
http://blog.racket-lang.org/2016/02/racket-v64.html
Racket's default package catalog is HTTPS now, not HTTP.

Racket also has a directory for all recently released installers and packages, it might be possible to replace the script with something that just pulls the x86_64 and i386 versions for Windows there instead of having to list the specific installer URL manually.
